### PR TITLE
Removed maxConnections and maxMessages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ var transport = nodemailer.createTransport(smtpTransport({
     auth: {
         user: 'username',
         pass: 'password'
-    },
-    maxConnections: 5,
-    maxMessages: 10
+    }
 }));
 ```
 
@@ -102,9 +100,7 @@ var transport = nodemailer.createTransport(smtpPool({
     service: 'gmail',
     auth: {
         xoauth2: generator
-    },
-    maxConnections: 5,
-    maxMessages: 10
+    }
 }));
 ```
 


### PR DESCRIPTION
Removed instances of maxConnections and maxMessages in the code snippets of the readme, as according to the smtp-transport-pool readme.md, they are what differentiates the two. Quoted from smtp-transport-pool readme: "Pooled SMTP transport uses the same options as SMTP transport **with the addition** of maxConnections and maxMessages."
