### PR TITLE
Update smtp-connection module version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "nodemailer-shared": "1.1.0",
     "nodemailer-wellknown": "0.1.10",
-    "smtp-connection": "2.12.0"
+    "smtp-connection": "4.0.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
In view of vulnerability CVE-2021-23358, described at https://exchange.xforce.ibmcloud.com/vulnerabilities/198958, propose to update smtp-connection node module version to the latest, 4.0.2, as the current version 2.12.0 incorporates version 1.7.0 of the underscore module via httpntlm version 1.6.1.